### PR TITLE
Fix Thread.sleep() which is not multiplying by 1000.

### DIFF
--- a/samples/javaclient/src/main/java/com/amazon/alexa/avs/auth/companionapp/CompanionAppAuthManager.java
+++ b/samples/javaclient/src/main/java/com/amazon/alexa/avs/auth/companionapp/CompanionAppAuthManager.java
@@ -245,7 +245,7 @@ public class CompanionAppAuthManager {
                         log.error(
                                 "There was a problem connecting to the LWA service. Trying again in {} seconds",
                                 TOKEN_REFRESH_RETRY_INTERVAL_IN_S);
-                        Thread.sleep(TOKEN_REFRESH_RETRY_INTERVAL_IN_S);
+                        Thread.sleep(TOKEN_REFRESH_RETRY_INTERVAL_IN_S * 1000);
                     } catch (InterruptedException ie) {
                         log.error("Interrupted while waiting to retry connecting to LWA", ie);
                     }


### PR DESCRIPTION
Discovered while trying to debug why I wasn't getting any tokens on boot, TOKEN_REFRESH_RETRY_INTERVAL_IN_S in this file is not being multiplied by 1000 as it is in CompanionServiceAuthManager.java