### PR TITLE
fixing #422 - vlclib default volume is 0

### DIFF
--- a/samples/javaclient/src/main/java/com/amazon/alexa/avs/AVSAudioPlayer.java
+++ b/samples/javaclient/src/main/java/com/amazon/alexa/avs/AVSAudioPlayer.java
@@ -356,6 +356,8 @@ public class AVSAudioPlayer {
                         if (!attemptedUrls.contains(mrl)) {
                             log.info("Playing {}", mrl);
                             mediaPlayer.playMedia(mrl);
+                            mediaPlayer.setVolume(100);
+			                mediaPlayer.getVolume();                            
                             return;
                         }
                     }
@@ -393,6 +395,8 @@ public class AVSAudioPlayer {
                 for (String mrl : streamUrls) {
                     if (!attemptedUrls.contains(mrl)) {
                         mediaPlayer.playMedia(mrl);
+                        mediaPlayer.setVolume(100);
+			            mediaPlayer.getVolume();                               
                         return;
                     }
                 }


### PR DESCRIPTION
fixes #422 by adding `mediaPlayer.setVolume(100)` and `mediaPlayer.getVolume()`