### PR TITLE
Adding Wiki documentation to MATRIX Creator hat Alexa demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ How is this different from the [last Amazon Alexa Pi project](https://github.com
 You can set up this project on the following platforms. Please choose the platform you'd like to set this up on -
 
 * [Raspberry Pi](../../wiki/Raspberry-Pi), or
+* [MATRIX Creator (RaspberryPi hat)](../../wiki/MatrixCreator), or
 * [Linux](../../wiki/Linux), or
 * [Mac](../../wiki/Mac), or
 * [Windows](../../wiki/Windows)


### PR DESCRIPTION
Hi Alexa team, 

We kindly request you add this PR from the [MATRIX Creator](https://creator.matrix.one/) team, that implements a working Alexa service demo using the mic array of our RaspberryPi compatible Hat and the Sensory library.


As [Github does not support pull requests on wiki pages][2], we  [forked the wiki page here][1] so you can check it out. The PR only contains changes on the `README.md` file and only make sense after the fork has been merged. Please let us know if you have any comments or require any further details. 

[1]: https://github.com/hpsaturn/alexa-avs-matrix-wiki/blob/master/MatrixCreator.md
[2]: http://stackoverflow.com/questions/10642928/how-to-pull-request-a-wiki-page-on-github