### PR TITLE
Fix to vlclib default volume is 0

### DIFF
--- a/samples/javaclient/src/main/java/com/amazon/alexa/avs/AVSAudioPlayer.java
+++ b/samples/javaclient/src/main/java/com/amazon/alexa/avs/AVSAudioPlayer.java
@@ -242,7 +242,9 @@ public class AVSAudioPlayer {
 
     private void setupAudioPlayer() {
         audioPlayer = new AudioMediaPlayerComponent();
-
+        // Force the volume to a value //
+        audioPlayer.getMediaPlayer().setVolume(100);
+        
         audioPlayer.getMediaPlayer().addMediaPlayerEventListener(new MediaPlayerEventAdapter() {
 
             private boolean playbackStartedSuccessfully;


### PR DESCRIPTION
A possible fix to #422  and #460, so far testing says it works. It changes the vlclib from volume being 0 when a stream starts and sets it to 100 instead