### PR TITLE
Enable KITT.AI Snowboy v1.2.0 for wake word engine

### DIFF
--- a/automated_install.sh
+++ b/automated_install.sh
@@ -563,7 +563,7 @@ cp $Kitt_Ai_Loc/snowboy/examples/C++/portaudio/install/include/pa_util.h $Extern
 cp $Kitt_Ai_Loc/snowboy/lib/$OS/libsnowboy-detect.a $External_Loc/lib/libsnowboy-detect.a
 cp $Kitt_Ai_Loc/snowboy/examples/C++/portaudio/install/lib/libportaudio.a $External_Loc/lib/libportaudio.a
 cp $Kitt_Ai_Loc/snowboy/resources/common.res $External_Loc/resources/common.res
-cp $Kitt_Ai_Loc/snowboy/resources/alexa.umdl $External_Loc/resources/alexa.umdl
+cp $Kitt_Ai_Loc/snowboy/resources/alexa/alexa-avs-sample-app/alexa.umdl $External_Loc/resources/alexa.umdl
 
 $Sensory_Loc/alexa-rpi/bin/sdk-license file $Sensory_Loc/alexa-rpi/config/license-key.txt $Sensory_Loc/alexa-rpi/lib/libsnsr.a $Sensory_Loc/alexa-rpi/models/spot-alexa-rpi-20500.snsr $Sensory_Loc/alexa-rpi/models/spot-alexa-rpi-21000.snsr $Sensory_Loc/alexa-rpi/models/spot-alexa-rpi-31000.snsr
 cp $Sensory_Loc/alexa-rpi/include/snsr.h $External_Loc/include/snsr.h

--- a/samples/wakeWordAgent/src/KittAiSnowboyWakeWordEngine.cpp
+++ b/samples/wakeWordAgent/src/KittAiSnowboyWakeWordEngine.cpp
@@ -25,7 +25,7 @@ namespace AlexaWakeWord {
 
 static const std::string  RESOURCE_FILE  = "../ext/resources/common.res";
 static const std::string  MODEL_FILE     = "../ext/resources/alexa.umdl";
-static const std::string  SENSITIVITY    = "0.5";
+// static const std::string  SENSITIVITY    = "0.5";
 static const float        AUDIO_GAIN     = 1.0;
 static const bool         APPLY_FRONTEND = true;
 static const int          MICROSECONDS_BETWEEN_SAMPLES = 100000;
@@ -102,11 +102,10 @@ void KittAiSnowboyWakeWordEngine::initDetector() {
       std::string("Initializing Kitt-Ai Snowboy library ") +
       " | resource file:" + RESOURCE_FILE +
       " | model file: " + MODEL_FILE +
-      " | sensitivity: " + SENSITIVITY +
       " | audio gain: " + std::to_string(AUDIO_GAIN));
 
   m_detector = make_unique<SnowboyDetect>(RESOURCE_FILE, MODEL_FILE);
-  m_detector->SetSensitivity(SENSITIVITY);
+  // m_detector->SetSensitivity(SENSITIVITY);
   m_detector->SetAudioGain(AUDIO_GAIN);
   m_detector->ApplyFrontend(APPLY_FRONTEND);
   m_isDetectorSetup = true;


### PR DESCRIPTION
1. This is a much improved version in terms of performance.
2. Use a dedicated model `snowboy/resources/alexa/alexa-avs-sample-app/alexa.umdl` for Alexa AVS sample app.
3. Comment out the sensitivity value from `samples/wakeWordAgent/src/KittAiSnowboyWakeWordEngine.cpp` so that it can use the default values from the model.
4. Amazon can use, modify, copy and redistribute the contribution.