### PR TITLE
Update KittAiSnowboyWakeWordEngine.cpp

### DIFF
--- a/samples/wakeWordAgent/src/KittAiSnowboyWakeWordEngine.cpp
+++ b/samples/wakeWordAgent/src/KittAiSnowboyWakeWordEngine.cpp
@@ -79,6 +79,7 @@ void KittAiSnowboyWakeWordEngine::resume() {
 
   log(Logger::INFO, "KittAiSnowboyWakeWordEngine: handling resume");
 
+  initDetector();
   initPortAudio();
 }
 


### PR DESCRIPTION
After playing with SetSensitivity and AUDIO_GAIN, I found that these updated settings work only for the 1st wakeword. When calling "Alexa" 2nd time sensitivity setting seem to be lost.
 
I added initDetector() at line 82 in order to set Sensitivity and AUDIO_GAIN values after resume.